### PR TITLE
Simplify vimrc to minimal config

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -1,20 +1,9 @@
 syntax on
 
-" Currently disabled cannot find a way to make line transparent.
-" set cursorline                                     " highlight current line
-" hi CursorLine term=none cterm=none ctermbg=LightGray      " adjust color
-
-" Disable compatability with vi for additional enhancements
 set nocompatible
-
-" Vim file type detection
 filetype off
 
-" Look in ~/.vim/colors for other color schemes
-colorscheme onedark "rupza
-
-" Sets background to be black
-highlight Normal ctermfg=grey ctermbg=black
+colorscheme slate
 
 set expandtab
 set shiftwidth=2
@@ -23,82 +12,7 @@ set number
 set autoindent
 set relativenumber
 
-" Backup to ~/.tmp 
-set backup 
-set backupdir=~/.vim-tmp,~/.tmp,~/tmp,/var/tmp,/tmp 
-set backupskip=/tmp/*,/private/tmp/* 
-set directory=~/.vim-tmp,~/.tmp,~/tmp,/var/tmp,/tmp 
-set writebackup
-
 command W w
 command Q q
 command WQ wq
 command Wq wq
-
-" Holding ctrl in insert mode allows you to move in Insert mode
-inoremap <C-h> <C-o>h
-inoremap <C-j> <C-o>j
-inoremap <C-k> <C-o>k
-inoremap <C-l> <C-o>l
-
-" Fast moving in Normal mode
-nnoremap <C-h> b
-nnoremap <C-l> w
-nnoremap <C-j> 3j
-nnoremap <C-k> 3k
-
-" Hop to beginning/end of line.
-nnoremap H ^
-nnoremap L $
-
-" Map motions associated with H and L
-vnoremap L $
-vnoremap H ^
-noremap dH d^
-noremap dL d$
-noremap cH c^
-noremap cL c$
-
-" Search and delete inner bracket hops to nearest bracket
-nnoremap ci( /(<CR> ci(
-nnoremap ci[ /[<CR> ci[
-nnoremap ci{ /{<CR> ci{
-nnoremap ci< /<<CR> ci<
-
-nnoremap di( /(<CR> di(
-nnoremap di[ /[<CR> di[
-nnoremap di{ /{<CR> di{
-nnoremap di< /<<CR> di<
-
-" Fixes strange hash on first line of file.
-set t_RV=
-
-" Start of vim-plug plugins (install with :PlugInstall)
-" https://github.com/junegunn/vim-plug
-call plug#begin('~/.vim/vim-plug-pluggins')
-
-Plug 'gmarik/vundle'
-Plug 'dag/vim-fish'
-"Plug 'terryma/vim-multiple-cursors'
-
-" Bottom status line 
-Plug 'vim-airline/vim-airline'
-Plug 'vim-airline/vim-airline-themes'
-Plug 'airblade/vim-gitgutter'
-
-" Adds vim text objects such as (C)hange (A)n (A)rgument - caa, 
-" and (D)elete (I)nner (A)rgument - dia for function definitions.
-Plug 'vim-scripts/argtextobj.vim'
-
-" Installs dark powered neo-completion (requires neovim to work!)
-if has('nvim')
-  Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
-else
-  Plug 'Shougo/deoplete.nvim'
-  Plug 'roxma/nvim-yarp'
-  Plug 'roxma/vim-hug-neovim-rpc'
-endif
-
-" Initialize plugin system
-call plug#end()
-


### PR DESCRIPTION
## Summary
- Removed custom keybindings, plugins, and vim-plug setup
- Switched from broken onedark colorscheme to built-in slate
- Kept core settings (syntax, indentation, line numbers) and command aliases (W, Q, WQ, Wq)

## Test plan
- [ ] Open vim and verify no errors on startup
- [ ] Confirm colorscheme and line numbers work

🤖 Generated with [Claude Code](https://claude.com/claude-code)